### PR TITLE
removing fields hover effect when blured

### DIFF
--- a/src/styles/Home.module.css
+++ b/src/styles/Home.module.css
@@ -45,6 +45,7 @@
 
 .blur {
   filter: blur(5px);
+  pointer-events: none;
 }
 
 @media screen and (max-width: 620px) {


### PR DESCRIPTION
When the menu is blured, the hover effect is no triggered anymore for the text fields
![image](https://user-images.githubusercontent.com/60229704/216755526-e627030d-1d13-4fdd-99b6-1e690eb6b604.png)
